### PR TITLE
Fix issue validate array

### DIFF
--- a/lib/type.ex
+++ b/lib/type.ex
@@ -216,6 +216,10 @@ defmodule Tarams.Type do
     mod.cast(value)
   end
 
+  defp array(term, _, _, _) when not is_list(term) do
+    :error
+  end
+
   defp array([nil | t], fun, true, acc) do
     array(t, fun, true, [nil | acc])
   end


### PR DESCRIPTION
Fix validate when value is not an array, it will raise error:

```
** (exit) an exception was raised:
    ** (FunctionClauseError) no function clause matching in Tarams.Type.array/4
        (tarams 1.2.0) lib/type.ex:219: Tarams.Type.array(1, #Function<4.69057566/1 in Tarams.Type."-fun.cast_integer/1-">, true, [])
        (tarams 1.2.0) lib/tarams.ex:170: Tarams.cast_field/2
        (elixir 1.12.3) lib/enum.ex:1586: anonymous fn/3 in Enum.map/2
        (stdlib 3.16) maps.erl:410: :maps.fold_1/3
        (elixir 1.12.3) lib/enum.ex:2397: Enum.map/2
```