### PR TITLE
support transform function return value instead of tuple

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,15 +231,23 @@ You can specify a function similar to `cast_func` to manipulate data after caste
 However data object passed to transform function is original data before casting.
 
 ```elixir
-data = %{name: "tada"}
+data = %{status: 10}
 
 schema = %{
     name: [type: :string, into: fn value -> {:ok, "name: #{value}}" end]
 }
 
 Tarams.cast(data, schema)
-
 # > %{name: "name: tada"}
+
+```
+
+- Transform function can return tuple `{:ok, value}`, `{:error, message}` or value directly.
+
+```elixir
+schema = %{
+    value: [type: :integer, into: &to_string/1]
+}
 ```
 
 

--- a/lib/tarams.ex
+++ b/lib/tarams.ex
@@ -148,6 +148,13 @@ defmodule Tarams do
     {status, Map.new(results)}
   end
 
+  def cast!(data, schema) do
+    case cast(data, schema) do
+      {:ok, value} -> value
+      _ -> raise "Tarams :: bad input data"
+    end
+  end
+
   defp cast_field(data, {field_name, definitions}) do
     {alias, definitions} = Keyword.pop(definitions, :as, field_name)
     {custom_message, definitions} = Keyword.pop(definitions, :message)

--- a/lib/tarams.ex
+++ b/lib/tarams.ex
@@ -257,21 +257,28 @@ defmodule Tarams do
 
   # transform data
   defp apply_transform(value, definitions, data) do
-    case definitions[:into] do
-      nil ->
-        {:ok, value}
+    result =
+      case definitions[:into] do
+        nil ->
+          {:ok, value}
 
-      {mod, func} when is_atom(mod) and is_atom(func) ->
-        apply(mod, func, [value, data])
+        {mod, func} when is_atom(mod) and is_atom(func) ->
+          apply(mod, func, [value, data])
 
-      func when is_function(func, 1) ->
-        func.(value)
+        func when is_function(func, 1) ->
+          func.(value)
 
-      func when is_function(func, 2) ->
-        func.(value, data)
+        func when is_function(func, 2) ->
+          func.(value, data)
 
-      _ ->
-        {:error, "invalid transform function"}
+        _ ->
+          {:error, "invalid transform function"}
+      end
+
+    # support function return tuple or value
+    case result do
+      {status, _value} when status in [:error, :ok] -> result
+      value -> {:ok, value}
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Tarams.MixProject do
   def project do
     [
       app: :tarams,
-      version: "1.3.0",
+      version: "1.3.1",
       elixir: "~> 1.10",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/test/tarams_test.exs
+++ b/test/tarams_test.exs
@@ -531,5 +531,25 @@ defmodule ParamTest do
 
       assert {:ok, %{product_status: "SUCCESS"}} = Tarams.cast(data, schema)
     end
+
+    test "transform function return value" do
+      convert_status = fn status ->
+        case status do
+          0 -> "draft"
+          1 -> "published"
+          2 -> "deleted"
+        end
+      end
+
+      schema = %{
+        status: [:integer, as: :product_status, into: convert_status]
+      }
+
+      data = %{
+        status: 0
+      }
+
+      assert {:ok, %{product_status: "draft"}} = Tarams.cast(data, schema)
+    end
   end
 end

--- a/test/tarams_test.exs
+++ b/test/tarams_test.exs
@@ -245,9 +245,19 @@ defmodule ParamTest do
       assert 10 = Tarams.Type.cast!(:integer, "10")
     end
 
-    test "cast raise exception" do
+    test "type cast raise exception" do
       assert_raise RuntimeError, fn ->
         Tarams.Type.cast!(:integer, "10xx")
+      end
+    end
+
+    test "Tarams.cast! success" do
+      assert %{number: 10} = Tarams.cast!(%{number: "10"}, %{number: :integer})
+    end
+
+    test "Tarams.cast! raise exception" do
+      assert_raise RuntimeError, fn ->
+        Tarams.cast!(%{number: 10}, %{number: {:array, :string}})
       end
     end
 


### PR DESCRIPTION

```elixir
convert_status = fn status ->
        case status do
          0 -> "draft"
          1 -> "published"
          2 -> "deleted"
        end
      end

      schema = %{
        status: [:integer, as: :product_status, into: convert_status]
      }

      data = %{
        status: 0
      }

      {:ok, %{product_status: "draft"}} = Tarams.cast(data, schema)
```