### PR TITLE
[BOAPI-1096] fix type checker

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+elixir 1.13.4-otp-25
+erlang 25.0

--- a/lib/tarams.ex
+++ b/lib/tarams.ex
@@ -135,6 +135,8 @@ defmodule Tarams do
     end
   end
 
+  defp cast_value("", %{} = type), do: cast_value(%{}, type)
+  defp cast_value(nil, %{} = type), do: cast_value(%{}, type)
   defp cast_value(nil, _), do: {:ok, nil}
 
   # cast array of custom map

--- a/lib/type.ex
+++ b/lib/type.ex
@@ -63,8 +63,6 @@ defmodule Tarams.Type do
 
   defp cast_decimal(term) when is_binary(term) do
     case Decimal.parse(term) do
-      {:ok, decimal} -> check_decimal(decimal, false)
-      # The following two clauses exist to support earlier versions of Decimal.
       {decimal, ""} -> check_decimal(decimal, false)
       {_, remainder} when is_binary(remainder) and byte_size(remainder) > 0 -> :error
       :error -> :error

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Tarams.MixProject do
   def project do
     [
       app: :tarams,
-      version: "1.6.1",
+      version: "1.6.1-ecc",
       elixir: "~> 1.10",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Tarams.MixProject do
   def project do
     [
       app: :tarams,
-      version: "1.6.1-ecc",
+      version: "1.6.2-ecc",
       elixir: "~> 1.10",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/test/tarams_test.exs
+++ b/test/tarams_test.exs
@@ -301,6 +301,30 @@ defmodule ParamTest do
                Tarams.cast(data, @schema)
     end
 
+    test "cast empty embed type should error" do
+      data = %{
+        user: ""
+      }
+
+      assert {:error, %{user: %{name: ["is required"]}}} = Tarams.cast(data, @schema)
+    end
+
+    test "cast empty map embed type should error" do
+      data = %{
+        user: %{}
+      }
+
+      assert {:error, %{user: %{name: ["is required"]}}} = Tarams.cast(data, @schema)
+    end
+
+    test "cast nil embed type should error" do
+      data = %{
+        user: nil
+      }
+
+      assert {:error, %{user: %{name: ["is required"]}}} = Tarams.cast(data, @schema)
+    end
+
     @tag :only
     test "cast missing required value should error" do
       data = %{


### PR DESCRIPTION
В elixir 1.19 TypeCheck стал более строгим.  
У `cast_decimal` есть мёртвая ветка case:
```shell
==> tarams
Compiling 4 files (.ex)
    warning: the following clause will never match:

        {:ok, decimal}

    because it attempts to match on the result of:

        Decimal.parse(term)

    which has type:

        dynamic(
          :error or
            {%Decimal{sign: integer(), coef: integer(), exp: float() or integer()} or
               %Decimal{sign: integer(), coef: :NaN or :inf, exp: integer()}, term()}
        )

    typing violation found at:
    │
 66 │       {:ok, decimal} -> check_decimal(decimal, false)
    │       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    │
    └─ lib/type.ex:66: Tarams.Type.cast_decimal/1
```

## Summary by Sourcery

Align type casting and decimal parsing with stricter type checking while tightening embed validation and updating project metadata.

Bug Fixes:
- Fix embed casting to treat empty string, empty map, and nil values for embedded maps as validation errors instead of silently accepting them.
- Remove an unreachable Decimal.parse match clause to satisfy stricter type checking in newer Elixir versions.

Enhancements:
- Add support for normalizing empty and nil embed payloads into a consistent map shape before casting.

Build:
- Bump project version to 1.6.1-ecc and add local tooling configuration via .tool-versions.

Tests:
- Add regression tests asserting that empty string, empty map, and nil values for an embedded schema produce required-field errors.